### PR TITLE
Make sample.env var names match vars in client call for supabase

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,4 @@
 # Populate this file with your own keys, then rename it to `.env`
 
-VITE_SUPABASE_ANON_KEY=
-VITE_SUPABASE_URL=
+VITE_PUBLIC_SUPABASE_URL=
+VITE_PUBLIC_SUPABASE_KEY=


### PR DESCRIPTION
Was getting errors when trying to run the dev server because the env variables did not match the ones being used in the supabase `createClient()` call.

Rename the variables in the `sample.env` file so it matches